### PR TITLE
Add no zhenyi/turg search modifiers

### DIFF
--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -343,6 +343,8 @@ const modifiersToChinese = {
   "No JST": ["无叶"],
   "No Newton": ["无牛"],
   "No Shuijing": ["无水"],
+  "No Zhenyi": ["无贞仪"],
+  "No Turgenev": ["无屠"],
   "SS LE": ["SS鬼", "2S鬼"],
   "SS lead skill": ["SS队长技", "2S队长技"],
   "Exalted MA": ["终极区"],


### PR DESCRIPTION
Finally got some terms to copy/paste after pestering people in the honkai discord; thanks to tempest#7070

Informally tested by eyeballing bilibili search results d-( '.  '  )z